### PR TITLE
Make AMQP transport optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ to be running on its own domain.
 
 The `acme-secret-dir` is the directory where the private key for the certificate
 will be cached.
+
+## AMQP support
+
+The AMQP support uses the CGo bindings to the [Apache Qpid library](https://qpid.apache.org/index.html).
+Set the build tag `amqp` to enable the output (ie build with `go build -tags amqp`)

--- a/server/amqp.go
+++ b/server/amqp.go
@@ -58,7 +58,7 @@ type amqpTransport struct {
 }
 
 func init() {
-	transports["aqmp"] = amqpTransportFromConfig
+	transports["amqp"] = amqpTransportFromConfig
 }
 
 // amqpTransportFromConfig creates a new AMQP transport if the supplied

--- a/server/amqp.go
+++ b/server/amqp.go
@@ -1,3 +1,5 @@
+//+build amqp
+
 package server
 
 //
@@ -53,6 +55,10 @@ type amqpTransport struct {
 	containerId   string
 	errors        chan LogEntry
 	address       string
+}
+
+func init() {
+	transports["aqmp"] = amqpTransportFromConfig
 }
 
 // amqpTransportFromConfig creates a new AMQP transport if the supplied

--- a/server/awsiot.go
+++ b/server/awsiot.go
@@ -1,4 +1,5 @@
 package server
+
 //
 //Copyright 2018 Telenor Digital AS
 //
@@ -46,6 +47,10 @@ type awsiotTransport struct {
 	clientCert string
 	privateKey string
 	client     mqtt.Client
+}
+
+func init() {
+	transports["awsiot"] = awsiotTransportFromConfig
 }
 
 func awsiotTransportFromConfig(tc model.TransportConfig) transport {

--- a/server/logoutput.go
+++ b/server/logoutput.go
@@ -1,0 +1,27 @@
+package server
+
+import "github.com/ExploratoryEngineering/congress/model"
+
+// Testing code below -------------------------------------------------------
+// logTransport is a simple log-only transport configuration. This is only
+// used for testing.
+type logTransport struct {
+}
+
+func newLogTransport(tc model.TransportConfig) transport {
+	return &logTransport{}
+}
+
+func (d *logTransport) open(ml *MemoryLogger) bool {
+	return true
+}
+
+func (d *logTransport) send(msg interface{}, ml *MemoryLogger) bool {
+	return true
+}
+func (d *logTransport) close(ml *MemoryLogger) {
+}
+
+func init() {
+	transports["log"] = newLogTransport
+}

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -1,4 +1,5 @@
 package server
+
 //
 //Copyright 2018 Telenor Digital AS
 //
@@ -49,6 +50,10 @@ type mqttTransport struct {
 	clientID  string
 	errors    chan LogEntry
 	topicName string
+}
+
+func init() {
+	transports["mqtt"] = mqttTransportFromConfig
 }
 
 // MQTTTransportFromConfig creates a new MQTT transport if the supplied

--- a/server/transport.go
+++ b/server/transport.go
@@ -1,4 +1,5 @@
 package server
+
 //
 //Copyright 2018 Telenor Digital AS
 //
@@ -48,12 +49,8 @@ func getTransport(op *model.AppOutput) transport {
 
 type transportFactory func(model.TransportConfig) transport
 
-var transports = map[string]transportFactory{
-	"mqtt":   mqttTransportFromConfig,
-	"amqp":   amqpTransportFromConfig,
-	"log":    newLogTransport,
-	"awsiot": awsiotTransportFromConfig,
-}
+// Each impplementation populates this map in their own init functino
+var transports = map[string]transportFactory{}
 
 // DeviceData is a wrapper for the model.DeviceData struct. This is used both
 // in the ../data endpoints and via websockets.
@@ -92,24 +89,4 @@ func newDeviceDataFromPayloadMessage(message *PayloadMessage) *deviceData {
 		DataRate:   message.FrameContext.GatewayContext.Radio.DataRate,
 		GatewayEUI: message.FrameContext.GatewayContext.Gateway.GatewayEUI.String(),
 	}
-}
-
-// Testing code below -------------------------------------------------------
-// logTransport is a simple log-only transport configuration. This is only
-// used for testing.
-type logTransport struct {
-}
-
-func newLogTransport(tc model.TransportConfig) transport {
-	return &logTransport{}
-}
-
-func (d *logTransport) open(ml *MemoryLogger) bool {
-	return true
-}
-
-func (d *logTransport) send(msg interface{}, ml *MemoryLogger) bool {
-	return true
-}
-func (d *logTransport) close(ml *MemoryLogger) {
 }


### PR DESCRIPTION
The AMQP transport requires an external C library and extra installs.

Make it optional by building only when the tag "amqp" is set, also make the different
transports configure themselves by setting the entry in the transports map in the
init function.